### PR TITLE
normalized list-view size svg files

### DIFF
--- a/public/svgs/frost/list-large.svg
+++ b/public/svgs/frost/list-large.svg
@@ -1,6 +1,13 @@
-<svg viewBox="0 0 15 15" >
-	<g id="Layer_1_1_" class="view-size-svg">
-		<rect x="0" y="0" width="15" height="7"/>
-		<rect x="0" y="8" width="15" height="7"/>
+<?xml version="1.0" encoding="utf-8"?>
+<svg 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xml:space="preserve"
+  version="1.1" id="Layer_1"
+  viewBox="0 0 10 10"
+>
+	<g class="view-size-svg">
+		<rect x="0" y="0" width="10" height="4.5"/>
+		<rect x="0" y="5.5" width="10" height="4.5"/>
 	</g>
 </svg>

--- a/public/svgs/frost/list-medium.svg
+++ b/public/svgs/frost/list-medium.svg
@@ -1,8 +1,15 @@
-<svg viewBox="0 0 15 15" >
-	<g id="Layer_1_1_" class="view-size-svg">
-		<rect x="0" y="4" width="15" height="3"/>
-		<rect x="0" y="8" width="15" height="3"/>
-		<rect x="0" y="12" width="15" height="3"/>
-		<rect x="0" y="0" width="15" height="3"/>
+<?xml version="1.0" encoding="utf-8"?>
+<svg 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xml:space="preserve"
+  version="1.1" id="Layer_1"
+  viewBox="0 0 10 10"
+>
+	<g class="view-size-svg">
+		<rect x="0" y="0" width="10" height="1.75"/>
+		<rect x="0" y="2.75" width="10" height="1.75"/>
+		<rect x="0" y="5.5" width="10" height="1.75"/>
+		<rect x="0" y="8.25" width="10" height="1.75"/>
 	</g>
 </svg>

--- a/public/svgs/frost/list-small.svg
+++ b/public/svgs/frost/list-small.svg
@@ -1,9 +1,16 @@
-<svg viewBox="0 0 15 15" >
-	<g id="Layer_1_1_" class="view-size-svg">
-		<rect x="0" y="0" width="15" height="1"/>
-		<rect x="0" y="3.334" width="15" height="1.4"/>
-		<rect x="0" y="6.746" width="15" height="1.4"/>
-		<rect x="0" y="10.157" width="15" height="1.4"/>
-		<rect x="0" y="13.568" width="15" height="1.4"/>
-	</g>
+<?xml version="1.0" encoding="utf-8"?>
+<svg 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xml:space="preserve"
+  version="1.1" id="Layer_1"
+  viewBox="0 0 10 10"
+>
+  <g class="view-size-svg">
+    <rect x="0" y="0" width="10" height="1"/>
+    <rect x="0" y="2.25" width="10" height="1"/>
+    <rect x="0" y="4.5" width="10" height="1"/>
+    <rect x="0" y="6.75" width="10" height="1"/>
+    <rect x="0" y="9" width="10" height="1"/>
+  </g>
 </svg>


### PR DESCRIPTION
#PATCH#

just normalizing these list-view-size SVGs so they are all same height without any styling or sizing, also cleans up a couple inconsistencies that were causing some weird fuzzies/artifacts