### PR TITLE
Fix issue in demo where entry was equal to ...

### DIFF
--- a/addon/components/frost-icon.js
+++ b/addon/components/frost-icon.js
@@ -13,6 +13,8 @@ export default Ember.Component.extend({
 
     if (_.isUndefined(svg)) {
       Ember.assert('The svg ' + this.get('icon') + ' does not exist')
+    } else if (typeof svg !== 'string') {
+      Ember.assert('The svg path ' + this.get('icon') + ' is incomplete')
     } else {
       let classes = _.isString(this.get('class')) ? ' ' + this.get('class') : ''
       svg = svg.replace('<svg', '<svg class="frost-icon' + classes + '"')

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -22,6 +22,12 @@ export default Ember.Controller.extend({
           icon,
           markdown: `\`${icon}\``
         }
+      }).filter((entry) => {
+        // filter out objects when used on frost-guide as it picks up other svgs (folder in folder)
+        // these nested folders return as objects with its properties equal to folders inside
+        if (typeof Ember.get(svgs, entry.icon.replace(/\//g, '.')) === 'string') {
+          return true
+        }
       }))
     }, [])
   }),


### PR DESCRIPTION
`{{frost-icon icon='folder/folder}}`. frost-icons would crash since this wasn't a valid svg
#fix#

I didn't want to get over zealous but I think we should also fix the component itself to gracefully catch a scenario where the `icon` is a folder. 

A more robust condition [here](https://github.com/ciena-frost/ember-frost-icons/blob/master/addon/components/frost-icon.js#L14) would do (since a folder is defined. But since it is an object it will crash on the [replace](https://github.com/ciena-frost/ember-frost-icons/blob/master/addon/components/frost-icon.js#L18).